### PR TITLE
debug: change `throw` to `warn` on broken links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ export default {
   tagline: 'DeFi made simple',
   url: 'https://docs.yearn.fi',
   baseUrl: '/',
-  onBrokenLinks: 'throw',
+  onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
   organizationName: 'yearn', // Usually your GitHub org/user name.


### PR DESCRIPTION
Still not building the vercel preview. Linter shows an error on broken links that aren't broken and it builds fine locally. Changing the error handling in the docusaurus config file to see if that fixes things.